### PR TITLE
test: Use testify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/sessions v1.2.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/rs/cors v1.7.0
+	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.1 // indirect
 	golang.org/x/net v0.0.0-20191003171128-d98b1b443823
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
@@ -56,9 +58,14 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.1 h1:8dP3SGL7MPB94crU3bEPplMPe83FI4EouesJUeFHv50=
@@ -167,8 +174,11 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.24.0 h1:vb/1TCsVn3DcJlQ0Gs1yB1pKI6Do2/QNwxdKqmc/b0s=
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/quiz/questionandanswer_test.go
+++ b/quiz/questionandanswer_test.go
@@ -1,6 +1,7 @@
 package quiz
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -19,15 +20,7 @@ func TestCreateReverse(t *testing.T) {
 		t.Error("createReverse() returned nil.")
 	}
 
-	if reverse.Id != ("reverse-" + TEST_ID) {
-		t.Error("The reverse QuestionAndAnswer did not have the expected ID.")
-	}
-
-	if reverse.Text.Text != TEST_ANSWER {
-		t.Error("The reverse QuestionAndAnswer did not have the expected title.")
-	}
-
-	if reverse.Answer.Text != TEST_QUESTION {
-		t.Error("The reverse QuestionAndAnswer did not have the expected answer.")
-	}
+	assert.Equal(t, "reverse-"+TEST_ID, reverse.Id)
+	assert.Equal(t, TEST_ANSWER, reverse.Text.Text)
+	assert.Equal(t, TEST_QUESTION, reverse.Answer.Text)
 }

--- a/quiz/quiz_test.go
+++ b/quiz/quiz_test.go
@@ -1,6 +1,7 @@
 package quiz
 
 import (
+	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"testing"
 )
@@ -47,17 +48,9 @@ func TestLoadQuiz(t *testing.T) {
 		t.Error("The quiz does not have the expected section.")
 	}
 
-	if section.Id != SECTION_ID {
-		t.Error("The section does not have the expected ID.")
-	}
-
-	if section.Title != "Data Structure Operations" {
-		t.Error("The section does not have the expected title.")
-	}
-
-	if section.Link != "" {
-		t.Error("The section does not have the expected link.")
-	}
+	assert.Equal(t, SECTION_ID, section.Id)
+	assert.Equal(t, "Data Structure Operations", section.Title)
+	assert.Equal(t, "", section.Link)
 
 	const QUESTION_ID = "b-tree-search-worst"
 	qa := q.GetQuestionAndAnswer(QUESTION_ID)
@@ -65,50 +58,22 @@ func TestLoadQuiz(t *testing.T) {
 		t.Error("The quiz does not have the expected question.")
 	}
 
-	if qa.Question.Id != QUESTION_ID {
-		t.Error("The question does not have the expected ID.")
-	}
-
-	if qa.Question.SectionId != SECTION_ID {
-		t.Error("The question does not have the expected SectionId.")
-	}
-
-	if qa.Question.Section.Id != SECTION_ID {
-		t.Error("The question does not have the expected section ID.")
-	}
-
-	if qa.Question.Section.Title != "Data Structure Operations" {
-		t.Error("The question does not have the expected section ID.")
-	}
+	assert.Equal(t, QUESTION_ID, qa.Question.Id)
+	assert.Equal(t, SECTION_ID, qa.Question.SectionId)
+	assert.Equal(t, SECTION_ID, qa.Question.Section.Id)
+	assert.Equal(t, "Data Structure Operations", qa.Question.Section.Title)
 
 	const SUB_SECTION_ID = "b-tree"
-	if qa.Question.SubSectionId != SUB_SECTION_ID {
-		t.Error("The question does not have the expected sub-section ID.")
-	}
+	assert.Equal(t, SUB_SECTION_ID, qa.Question.SubSectionId)
+	assert.Equal(t, SUB_SECTION_ID, qa.Question.SubSection.Id)
+	assert.Equal(t, "B-Tree", qa.Question.SubSection.Title)
 
-	if qa.Question.SubSection.Id != SUB_SECTION_ID {
-		t.Error("The question does not have the expected sub-section ID.")
-	}
+	assert.Equal(t, "Search (Worst)", qa.Question.Text.Text)
+	assert.Equal(t, false, qa.Question.Text.IsHtml)
 
-	if qa.Question.SubSection.Title != "B-Tree" {
-		t.Error("The question does not have the expected sub-section Title.")
-	}
+	assert.Equal(t, "O(log(n))", qa.Answer.Text)
 
-	if qa.Question.Text.Text != "Search (Worst)" {
-		t.Error("The question does not have the expected text.")
-	}
-
-	if qa.Question.Text.IsHtml {
-		t.Error("The question does not have the expected isHtml value.")
-	}
-
-	if qa.Answer.Text != "O(log(n))" {
-		t.Error("The question does not have the expected answer text.")
-	}
-
-	if len(qa.Question.Choices) == 0 {
-		t.Error("The question does not have any choices")
-	}
+	assert.NotEmpty(t, qa.Question.Choices)
 }
 
 func TestLoadQuizWithReverseSection(t *testing.T) {
@@ -124,17 +89,9 @@ func TestLoadQuizWithReverseSection(t *testing.T) {
 		t.Error("The quiz does not have the expected reverse section.")
 	}
 
-	if section.Id != SECTION_ID {
-		t.Error("The reverse section does not have the expected ID.")
-	}
-
-	if section.Title != "Reverse: Hash Tables" {
-		t.Error("The reverse section does not have the expected title.")
-	}
-
-	if section.Link != "https://en.wikipedia.org/wiki/Hash_table" {
-		t.Error("The reverse section does not have the expected link.")
-	}
+	assert.Equal(t, SECTION_ID, section.Id)
+	assert.Equal(t, "Reverse: Hash Tables", section.Title)
+	assert.Equal(t, "https://en.wikipedia.org/wiki/Hash_table", section.Link)
 
 	const QUESTION_ID = "reverse-datastructures-hash-tables-open-addressing-strategy-probe-sequence"
 	qa := q.GetQuestionAndAnswer(QUESTION_ID)
@@ -142,48 +99,20 @@ func TestLoadQuizWithReverseSection(t *testing.T) {
 		t.Error("The quiz does not have the expected reverse question.")
 	}
 
-	if qa.Question.Id != QUESTION_ID {
-		t.Error("The reverse question does not have the expected ID.")
-	}
-
-	if qa.Question.SectionId != SECTION_ID {
-		t.Error("The reverse question does not have the expected SectionId.")
-	}
-
-	if qa.Question.Section.Id != SECTION_ID {
-		t.Error("The reverse question does not have the expected section ID.")
-	}
-
-	if qa.Question.Section.Title != "Reverse: Hash Tables" {
-		t.Error("The reverse question does not have the expected section ID.")
-	}
+	assert.Equal(t, QUESTION_ID, qa.Question.Id)
+	assert.Equal(t, SECTION_ID, qa.SectionId)
+	assert.Equal(t, SECTION_ID, qa.Section.Id)
+	assert.Equal(t, "Reverse: Hash Tables", qa.Section.Title)
 
 	const SUB_SECTION_ID = "datastructures-hash-tables-open-addressing-strategies"
-	if qa.Question.SubSectionId != SUB_SECTION_ID {
-		t.Error("The question does not have the expected subSectionId.")
-	}
+	assert.Equal(t, SUB_SECTION_ID, qa.Question.SubSectionId)
+	assert.Equal(t, SUB_SECTION_ID, qa.Question.SubSection.Id)
 
-	if qa.Question.SubSection.Id != SUB_SECTION_ID {
-		t.Error("The question does not have the expected sub-section ID.")
-	}
+	assert.Equal(t, "Open addressing strategies", qa.Question.SubSection.Title)
+	assert.Equal(t, "The buckets are examined, starting with the hashed-to slot and proceeding in some probe sequence, until an unoccupied slot is found.", qa.Question.Text.Text)
+	assert.Equal(t, false, qa.Question.Text.IsHtml)
 
-	if qa.Question.SubSection.Title != "Open addressing strategies" {
-		t.Error("The question does not have the expected sub-section title.")
-	}
+	assert.Equal(t, "Probe sequence", qa.Answer.Text)
 
-	if qa.Question.Text.Text != "The buckets are examined, starting with the hashed-to slot and proceeding in some probe sequence, until an unoccupied slot is found." {
-		t.Error("The question does not have the expected text.", qa.Question.Text.Text)
-	}
-
-	if qa.Question.Text.IsHtml {
-		t.Error("The question does not have the expected isHtml value.")
-	}
-
-	if qa.Answer.Text != "Probe sequence" {
-		t.Error("The question does not have the expected answer text.", qa.Answer.Text)
-	}
-
-	if len(qa.Question.Choices) == 0 {
-		t.Error("The question does not have any choices")
-	}
+	assert.NotEmpty(t, qa.Question.Choices)
 }


### PR DESCRIPTION
Officially, Go tests are meant to use the long-winded syntax, but I
really find this more readable, and the results are clear enough.