### PR TITLE
convertDomainStatsToRestStats(): Use questions count for the section

### DIFF
--- a/server/restserver/quizcache.go
+++ b/server/restserver/quizcache.go
@@ -124,8 +124,29 @@ func (self *QuizCache) GetRandomQuestion(sectionId string) *restquiz.Question {
 	}
 }
 
+// GetQuestionsCount returns the number of questions in the entire quiz.
 func (self *QuizCache) GetQuestionsCount() int {
 	return len(self.questionsArray)
+}
+
+// GetSectionQuestionsCount returns the number of questions in the section and all its sub-sections.
+func (self *QuizCache) GetSectionQuestionsCount(sectionId string) int {
+	section, err := self.GetSection(sectionId)
+	if err != nil || section == nil {
+		return 0
+	}
+
+	result := len(section.Questions)
+
+	for _, subSection := range section.SubSections {
+		if subSection == nil {
+			continue
+		}
+
+		result += len(subSection.Questions)
+	}
+
+	return result
 }
 
 func (self *QuizCache) GetAnswer(questionId string) *restquiz.Text {

--- a/server/restserver/restuserhistory.go
+++ b/server/restserver/restuserhistory.go
@@ -71,10 +71,6 @@ func (s *RestServer) HandleUserHistoryAll(w http.ResponseWriter, r *http.Request
 				return
 			}
 
-			// Set extras for REST:
-			restStats.QuizTitle = q.Title
-			restStats.CountQuestions = quizCache.GetQuestionsCount()
-
 			info.AddQuizStats(q.Id, restStats)
 		}
 	}
@@ -601,11 +597,6 @@ func (s *RestServer) buildRestUserHistorySections(loginInfo *restuser.LoginInfo,
 			log.Printf("convertDomainStatsToRestStats() failed: %v", err)
 			continue
 		}
-
-		// Set extras for REST:
-		restStats.QuizTitle = quiz.Title
-		restStats.SectionTitle = section.Title
-		restStats.CountQuestions = quizCache.GetQuestionsCount()
 
 		err = s.fillUserStatsWithExtras(restStats, quiz)
 		if err != nil {

--- a/server/restserver/user_converters.go
+++ b/server/restserver/user_converters.go
@@ -23,6 +23,15 @@ func convertDomainStatsToRestStats(stats *domainuser.Stats, quizCache *QuizCache
 		sectionTitle = section.Title
 	}
 
+	questionsCount := 0
+	if len(stats.SectionId) == 0 {
+		// This should be stats for a whole quiz.
+		questionsCount = quizCache.GetQuestionsCount()
+	} else {
+		// This should be stats for just one section.
+		questionsCount = quizCache.GetSectionQuestionsCount(stats.SectionId)
+	}
+
 	return &restuser.Stats{
 		QuizId:                     stats.QuizId,
 		SectionId:                  stats.SectionId,
@@ -32,7 +41,7 @@ func convertDomainStatsToRestStats(stats *domainuser.Stats, quizCache *QuizCache
 		CountQuestionsCorrectOnce:  stats.CountQuestionsCorrectOnce,
 		QuestionHistories:          questionHistories,
 
-		CountQuestions: quizCache.GetQuestionsCount(),
+		CountQuestions: questionsCount,
 		QuizTitle:      quizCache.Quiz.Title,
 		SectionTitle:   sectionTitle,
 	}, nil

--- a/server/restserver/user_converters_test.go
+++ b/server/restserver/user_converters_test.go
@@ -138,7 +138,7 @@ func TestConvertDomainQuestionHistoryToRestQuestionHistory(t *testing.T) {
 	assert.Equal(t, obj.CountAnsweredWrong, result.CountAnsweredWrong)
 }
 
-func TestConvertDomainStatsToRestStats(t *testing.T) {
+func TestConvertDomainStatsToRestStatsPerSection(t *testing.T) {
 	quiz := testRestQuiz()
 
 	section := quiz.Sections[1]
@@ -196,7 +196,37 @@ func TestConvertDomainStatsToRestStats(t *testing.T) {
 	assert.Equal(t, obj.QuestionHistories[1].CountAnsweredWrong, qh1.CountAnsweredWrong)
 
 	// Extras:
-	assert.Equal(t, quizCache.GetQuestionsCount(), result.CountQuestions)
+	assert.Equal(t, quizCache.GetSectionQuestionsCount(section.Id), result.CountQuestions)
 	assert.Equal(t, quizCache.Quiz.Title, result.QuizTitle)
 	assert.Equal(t, section.Title, result.SectionTitle)
+}
+
+func TestConvertDomainStatsToRestStatsPerQuiz(t *testing.T) {
+	quiz := testRestQuiz()
+
+	obj := domainuser.Stats{
+		QuizId:                     quiz.Id,
+		SectionId:                  "",
+		Answered:                   11,
+		Correct:                    9,
+		CountQuestionsAnsweredOnce: 5,
+		CountQuestionsCorrectOnce:  4,
+		QuestionHistories:          nil,
+	}
+
+	quizCache, err := NewQuizCache(quiz)
+	assert.Nil(t, err)
+	assert.NotNil(t, quizCache)
+
+	result, err := convertDomainStatsToRestStats(&obj, quizCache)
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+
+	assert.Equal(t, obj.QuizId, result.QuizId)
+	assert.Equal(t, obj.SectionId, result.SectionId)
+
+	// Extras:
+	assert.Equal(t, quizCache.GetQuestionsCount(), result.CountQuestions)
+	assert.Equal(t, quizCache.Quiz.Title, result.QuizTitle)
+	assert.Empty(t, result.SectionTitle)
 }


### PR DESCRIPTION
Otherwise, the user sees all sections as having the total number of
questions for the whole quiz.

This also removes the unnecessary (and now obviously wrong) explicit
setting of these fields, which was already done in the previous calls to
convertDomainStatsToRestStats().