### PR TITLE
CI: Use go 1.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.12
-      uses: actions/setup-go@v1
+    - name: Set up Go
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.12
+        go-version: 1.14
       id: go
 
     - name: Check out
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build
       run: make


### PR DESCRIPTION
And update the version of the checkout and setup-go actions.