### PR TITLE
config_oauth2: Add example files for facebook and google too

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This is the go-based backend server implementation for bigoquiz.com.
     $ cd go-bigoquiz-server
     $ go build
 
-    ./config_use_prod.sh
     $ gcloud app deploy .
 
 ### Running locally
@@ -29,10 +28,6 @@ This is the go-based backend server implementation for bigoquiz.com.
     Change the configuration by applying the patch:
     $ patch -p1 < ./0001-debugging-Use-localhost.patch
       (Don't git push this)
-
-    Use an appropriate oauth2 config file:
-    (These cannot be added to the git repository.)
-    ./config_use_local.sh
 
     Then start the local server:
     $ dev_appserver.py .

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,4 @@
+{
+  "cookie-store-key": "REPLACE_THIS"
+}
+

--- a/config_oauth2/facebook_credentials_secret.json.example
+++ b/config_oauth2/facebook_credentials_secret.json.example
@@ -1,0 +1,4 @@
+{
+  "client_id":"REPLACE_THIS",
+  "client_secret":"REPLACE_THIS"
+}

--- a/config_oauth2/google_credentials_secret.json.example
+++ b/config_oauth2/google_credentials_secret.json.example
@@ -1,0 +1,4 @@
+{
+  "client_id":"REPLACE_THIS",
+  "client_secret":"REPLACE_THIS"
+}


### PR DESCRIPTION
There was already one for github. This makes it clearer that we need all
3 files, and what their filesnames (without the .example suffix) should
be.